### PR TITLE
Changing regex to allow for ";" in properties object

### DIFF
--- a/cartman/text.py
+++ b/cartman/text.py
@@ -167,7 +167,7 @@ def extract_properties(raw_html):
     :param raw_html: Dump from the query page.
 
     """
-    re_prop = r"var properties=([^;]+)"
+    re_prop = r"var properties=(.+);"
     prop_tokens = re.findall(re_prop, raw_html, re.MULTILINE)
 
     if len(prop_tokens) < 1:


### PR DESCRIPTION
Our Trac install had an item in the requirements object that contained a ";" which broke this tool. The change I made fixes that for us. Thanks!
