### PR TITLE
Add support for no authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ available:
 - ``username`` - required
 - ``password`` - required
 - ``auth_type`` - forces an authentication type, currently available: ``basic``
-  (default), ``digest``.
+  (default), ``digest``, ``none``.
 - ``verify_ssl_cert`` - ignore self-signed or invalid SSL certificates if set
   to false.
 - ``editor`` - override the editor defined the ``$EDITOR`` environment

--- a/cartman/app.py
+++ b/cartman/app.py
@@ -42,6 +42,7 @@ AUTH_TYPES = {
     "basic": requests.auth.HTTPBasicAuth,
     "digest": requests.auth.HTTPDigestAuth,
     "acctmgr": lambda a, b: None,
+    "none": None,
 }
 
 DEFAULT_TEMPLATE = """To:
@@ -92,7 +93,8 @@ class CartmanApp(object):
         self.session = requests.session()
 
         auth_class = AUTH_TYPES[self.auth_type]
-        self.session.auth = auth_class(self.username, self.password)
+        if auth_class:
+            self.session.auth = auth_class(self.username, self.password)
         self.session.verify = self.verify_ssl_cert
 
         func_name = "run_" + args.command
@@ -300,6 +302,10 @@ class CartmanApp(object):
 
         """
         if self.logged_in:
+            return
+
+        if self.auth_type == "none":
+            self.logged_in = True
             return
 
         # Seems that depending on the method used to serve trac, we need to use


### PR DESCRIPTION
Allows using the Trac project trac instance w/out an account
(typical). See https://trac.edgewall.org