### PR TITLE
Stub a simple makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install
+	python setup.py install


### PR DESCRIPTION
Only exposes an `install` and an `help` rule,
with `help` rendering comments on the rules