### PR TITLE
Use SafeConfigParser to allow variables interpolation

### DIFF
--- a/cartman/app.py
+++ b/cartman/app.py
@@ -145,7 +145,7 @@ class CartmanApp(object):
             "verify_ssl_cert": "true",
         }
 
-        cp = configparser.RawConfigParser(defaults)
+        cp = configparser.SafeConfigParser(defaults)
         cp.read(CONFIG_LOCATIONS)
 
         if not cp.has_option(self.site, "base_url"):


### PR DESCRIPTION
Simplifies configuration management
See
https://docs.python.org/2/library/configparser.html#ConfigParser.SafeConfigParser